### PR TITLE
Bump formula

### DIFF
--- a/.github/scripts/bump-formula.sh
+++ b/.github/scripts/bump-formula.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+# Bump formula version
+#
+# Usage: env FORMULA_NAME=<NAME> FORMULA_VERSION=<VERSION> ./bump-formula.sh
+
+set -eo pipefail
+
+# Install tap repository
+brew tap RedMadRobot/formulae ./
+# The path to the formula in tap
+FORMULA_PATH=$(brew formula "$FORMULA_NAME")
+
+# Bump formula version in tap repo
+# in latest brew `--write` renamed to `--write-only`
+brew bump-formula-pr \
+  --no-browse \
+  --no-audit \
+  --write \
+  --no-fork \
+  --version "$FORMULA_VERSION" \
+  "$FORMULA_NAME"
+
+# Show the modified formula
+brew cat "$FORMULA_NAME"
+# Copy the modified formula from the tap to the current repo
+cp "$FORMULA_PATH" ./
+
+git add "$FORMULA_NAME".rb
+git commit -m "Bump version $FORMULA_NAME $FORMULA_VERSION"
+git push

--- a/.github/workflows/bump-formula.yml
+++ b/.github/workflows/bump-formula.yml
@@ -1,0 +1,22 @@
+name: Bump formula
+on:
+  workflow_dispatch:
+    inputs:
+      formula:
+        description: 'formula name'
+        required: true
+      version:
+        description: 'formula version'
+        required: true
+jobs:
+  bump-formula-version:
+    name: Bump Homebrew formula verion
+    runs-on: macOS-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Bump formula
+        run: ./.github/scripts/bump-formula.sh
+        env:
+          FORMULA_NAME: ${{ github.event.inputs.formula }}
+          FORMULA_VERSION: ${{ github.event.inputs.version }}

--- a/.github/workflows/bump-formula.yml
+++ b/.github/workflows/bump-formula.yml
@@ -10,7 +10,7 @@ on:
         required: true
 jobs:
   bump-formula-version:
-    name: Bump Homebrew formula verion
+    name: Bump Homebrew formula version
     runs-on: macOS-latest
     steps:
       - name: Checkout


### PR DESCRIPTION
# Автоматизация обновления версии формулы

**Цель**: Автоматизировать обновление версии формулы в одном месте, чтобы использовать из других скриптов или через сайт самого GitHub

## Homebrew

У `brew` есть команда `bump-formula-pr`. Она поднимает версию формулы внутри `tap` репозитория и делает PR с обновлением. Сложность в том, что `tap` репозиторий после установки находится внутри Homebrew. Поэтому нужно копировать обновленную формулу в текущий репозиторий.

Используемый опции `bump-formula-pr`

- `--no-browse` - не открывать браузер с PR.
- `--no-audit` - не проверять корректность формулы
- `--write` - сделать только запись обновлений файлов без git команд
- `--no-fork` - не делать форка `tap` репозитория
- `--version <version>` - новая версия формулы

> `--write` была заменена на `--write-only` в новых версиях Homebrew,
> но в GitHub [macOS 10.15](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-10.15-Readme.md) осталась старая версия Homebrew.

В итоге `bump-formula-pr` обновляет версию внутри `url` и `sha256`

```diff
class Catbird < Formula
    ...
-   url "https://github.com/RedMadRobot/catbird/releases/download/0.8.0/catbird.zip"
-   sha256 "a1d6c25da916c9e5336571e69137134a6f8c0c10d2ba05fc917e70531f7b72cd"
+   url "https://github.com/RedMadRobot/catbird/releases/download/0.8.1/catbird.zip"
+   sha256 "7356e7851a20723a7c84438dfbe246415674a04f7d58bf114b6fc870b3ed1a70"
    ...
```  

## GitHub Actions

Workflow обновления формулы находится в`.github/workflows/bump-formula.yml` и запускается вручную.

Подробнее про ручной запуск workflow:

- [GitHub Actions: Manual triggers with workflow_dispatch](https://github.blog/changelog/2020-07-06-github-actions-manual-triggers-with-workflow_dispatch/)
- [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow)

Workflow обновления имеет два обязательных параметра:

- `formula` - Имя формулы
- `version` - Новая версия формулы

Они передаются в баш скрипт, который лежит в `.github/scripts/bump-formula.sh`, соответсвие с рекомендациями [Essential features of GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/essential-features-of-github-actions)

## GitHub CLI

У GitHub есть команд лайн инструмент `gh`, его можно установить себе на компьютер, а также он сразу установлен GitHub Actions.

- [Using GitHub CLI in workflows](https://docs.github.com/en/actions/advanced-guides/using-github-cli-in-workflows)
- [Work with GitHub Actions in your terminal with GitHub CLI](https://github.blog/2021-04-15-work-with-github-actions-in-your-terminal-with-github-cli/)

Примечателен `gh` тем, что может запускать `workflow`.

```bash
gh workflow run bump-formula.yml --repo RedMadRobot/homebrew-formulae --field formula=catbird --field version=0.8.1
```

Для работы внутри GitHub Actions ему нужно передать токен. Для манипуляций над текущим репозиторием ему может хватить дефлотного токена `secrets.GITHUB_TOKEN`, который есть в каждой репе.

```yml
- name: Upload GitHub Release Assets
  run: gh release upload ${{ github.event.release.tag_name }} archive.zip
  env:
    GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Но для манипуляций с другими репозиториями нужно установить свой персональный токен.

```yml
- name: Bump formula
  run: gh workflow run bump-formula.yml --repo RedMadRobot/homebrew-formulae --field formula=${{ github.event.inputs.formula }} --field version=${{ github.event.inputs.version }}
  env:
    GITHUB_TOKEN: ${{ secrets.GH_PERSONAL_TOKEN }}
```

## Как проверить?

Предлагаю слить PR и проверить работу вручную на специальных ветках, в которых нужно будет понизить версию формулы и потом её поднять с помощью `gh workflow run bump-formula.yml ...`, либо через сайт.
