### PR TITLE
Removed bottle in catbird.rb

### DIFF
--- a/catbird.rb
+++ b/catbird.rb
@@ -4,8 +4,6 @@ class Catbird < Formula
   url "https://github.com/RedMadRobot/catbird/releases/download/0.11.0/catbird.zip"
   sha256 "6e003cf5ba1eb9cc8a2c0a0a772c4249ed45989486286209e0550df1c79d1967"
 
-  bottle :unneeded
-
   def install
     bin.install "catbird"
   end


### PR DESCRIPTION
Fix error

```bash
brew install --formula catbird.rb
Error: catbird: Calling bottle :unneeded is disabled! There is no replacement.
```